### PR TITLE
Allow to supply the MySQL replication user

### DIFF
--- a/README
+++ b/README
@@ -102,6 +102,11 @@ Command line parameters
    http://www.consol.com/opensource/nagios/check-mysql-health for a list
    of features.
 
+--replication-user=<username of replication user>
+  This is the username used to authenticated mysql replication, this is useful
+  with the longprocs mode where the replication users process is not counted as
+  a longrunning process.
+
 --warning=<warning threshold>
   If the metric is out of this range, the plugin returns a warning.
 

--- a/plugins-scripts/Nagios/DBD/MySQL/Server.pm
+++ b/plugins-scripts/Nagios/DBD/MySQL/Server.pm
@@ -44,6 +44,7 @@ sub new {
     socket => $params{socket},
     username => $params{username},
     password => $params{password},
+    replication_user => $params{replication_user},
     mycnf => $params{mycnf},
     mycnfgroup => $params{mycnfgroup},
     timeout => $params{timeout},

--- a/plugins-scripts/Nagios/DBD/MySQL/Server/Instance.pm
+++ b/plugins-scripts/Nagios/DBD/MySQL/Server/Instance.pm
@@ -13,6 +13,7 @@ sub new {
   my $self = {
     handle => $params{handle},
     uptime => $params{uptime},
+    replication_user => $params{replication_user},
     warningrange => $params{warningrange},
     criticalrange => $params{criticalrange},
     threads_connected => undef,
@@ -135,23 +136,23 @@ sub init {
         $self->{delta_timestamp};
   } elsif ($params{mode} =~ /server::instance::longprocs/) {
     if (DBD::MySQL::Server::return_first_server()->version_is_minimum("5.1")) {
-      ($self->{longrunners}) = $self->{handle}->fetchrow_array(q{
+      ($self->{longrunners}) = $self->{handle}->fetchrow_array(qq(
           SELECT
               COUNT(*)
           FROM
               information_schema.processlist
-          WHERE user <> 'replication' 
+          WHERE user <> '$self->{replication_user}'
           AND id <> CONNECTION_ID() 
           AND time > 60 
           AND command <> 'Sleep'
-      });
+      ));
     } else {
       $self->{longrunners} = 0 if ! defined $self->{longrunners};
       foreach ($self->{handle}->fetchall_array(q{
           SHOW PROCESSLIST
       })) {
         my($id, $user, $host, $db, $command, $tme, $state, $info) = @{$_};
-        if (($user ne 'replication') &&
+        if (($user ne $self->{replication_user}) &&
             ($tme > 60) &&
             ($command ne 'Sleep')) {
           $self->{longrunners}++;

--- a/plugins-scripts/check_mysql_health.pl
+++ b/plugins-scripts/check_mysql_health.pl
@@ -192,6 +192,8 @@ sub print_usage () {
        the mysql db user's password
     --database
        the database's name. (default: information_schema)
+    --replication-user
+       the database's replication user name (default: replication)
     --warning
        the warning range
     --critical
@@ -295,6 +297,7 @@ my @params = (
     "socket|S=s",
     "username|u=s",
     "password|p=s",
+    "replication-user=s",
     "mycnf=s",
     "mycnfgroup=s",
     "mode|m=s",
@@ -553,6 +556,7 @@ my %params = (
     password => $commandline{password} || 
         $ENV{NAGIOS__SERVICEMYSQL_PASS} ||
         $ENV{NAGIOS__HOSTMYSQL_PASS},
+    replication_user => $commandline{'replication-user'} || 'replication',
     mycnf => $commandline{mycnf} || 
         $ENV{NAGIOS__SERVICEMYSQL_MYCNF} ||
         $ENV{NAGIOS__HOSTMYSQL_MYCNF},


### PR DESCRIPTION
This allows to supply a replication username on the command line to specify the username in case the username differs from the default `replication`. It still default to `replication` but allows for different values.