### PR TITLE
update fragmentation query, adapt to new default table size

### DIFF
--- a/plugins-scripts/Nagios/DBD/MySQL/Server/Instance.pm
+++ b/plugins-scripts/Nagios/DBD/MySQL/Server/Instance.pm
@@ -289,8 +289,8 @@ sub init {
     $self->{fragmented} = [];
     #http://www.electrictoolbox.com/optimize-tables-mysql-php/
     my  @result = $self->{handle}->fetchall_array(q{
-        SHOW TABLE STATUS
-    });
+SHOW TABLE STATUS WHERE Data_free / Data_length > 0.1 AND Data_free > 8388608
+});
     foreach (@result) {
       my ($name, $engine, $data_length, $data_free) =
           ($_->[0], $_->[1], $_->[6 ], $_->[9]);

--- a/plugins-scripts/Nagios/DBD/MySQL/Server/Instance/Innodb.pm
+++ b/plugins-scripts/Nagios/DBD/MySQL/Server/Instance/Innodb.pm
@@ -139,7 +139,7 @@ sub init {
 
 #http://www.electrictoolbox.com/optimize-tables-mysql-php/
     my  @result = $self->{handle}->fetchall_array(q{
-SHOW TABLE STATUS WHERE Data_free / Data_length > 0.1 AND Data_free > 102400
+SHOW TABLE STATUS WHERE Data_free / Data_length > 0.1 AND Data_free > 8388608
 });
 printf "%s\n", Data::Dumper::Dumper(\@result);
 


### PR DESCRIPTION
looks like mysql 5.7 they changed default table size (from 102400 to 8388608) that cause check to show false list of fragmented tables